### PR TITLE
APIを配列で指定できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ module.exports = {
       options: {
         apiKey: 'MICROCMS_API_KEY',
         serviceId: 'myblog',
-        endpoint: 'posts',
+        apis: [{
+          endpoint: 'posts',
+        }],
       },
     },
   ],
@@ -91,7 +93,7 @@ module.exports = {
         apiKey: '11111111-2222-3333-4444-555555555555',
 
         /**
-         * Subdomain information. (Required)
+         * Service information. (Required)
          * xxxx.microcms.io
          *
          * Type: string.
@@ -99,59 +101,59 @@ module.exports = {
         serviceId: 'xxxx',
 
         /**
-         * API endpoint name. (Required)
-         * https://xxxx.microcms.io/api/v1/posts
+         * API information. (Required)
+         * Multiple APIs can be specified.
          *
-         * Type: string.
+         * Type: array.
          **/
-        endpoint: 'posts',
+        apis: [{
+          /**
+           * API endpoint name. (Required)
+           * https://xxxx.microcms.io/api/v1/posts
+           *
+           * Type: string.
+           **/
+          endpoint: 'posts',
 
-        /**
-         * Graphql type. (Optional)
-         * This is used in GraphQL queries.
-         * If type = 'post', the GraphQL types are named 'microcmsPost' and 'allMicrocmsPost'.
-         *
-         * Type: string.
-         * Default: endpoint value.
-         **/
-        type: 'post',
+          /**
+           * Graphql type. (Optional)
+           * This is used in GraphQL queries.
+           * If type = 'post', the GraphQL types are named 'microcmsPost' and 'allMicrocmsPost'.
+           *
+           * Type: string.
+           * Default: endpoint value.
+           **/
+          type: 'post',
 
-        /**
-         * microCMS's content type('list' or 'object'). (Optional)
-         *
-         * Type: string.
-         * Default: 'list'.
-         **/
-        format: 'object',
+          /**
+           * microCMS's content type('list' or 'object'). (Optional)
+           *
+           * Type: string.
+           * Default: 'list'.
+           **/
+          format: 'object',
 
-        /**
-         * if format is 'list' and readAll is true then read all contents with fetchs which divided into multiple times. (Optional)
-         *
-         * Type: boolean.
-         * Default: false.
-         **/
-        readAll: true,
-
-        /**
-         * API request query options. (Optional)
-         *
-         * Type:
-         *   draftKey: string.
-         *   limit: number.
-         *   offset: number.
-         *   fields: string.
-         *   filters: string.
-         *   depth: number.
-         * Default: {}.
-         **/
-        query: {
-          draftKey: 'DRAFT_KEY',
-          limit: 100,
-          offset: 40,
-          fields: ['id', 'title', 'body'].join(','),
-          filters: 'tag[exists]',
-          depth: 2
-        }
+          /**
+           * API request query options. (Optional)
+           *
+           * Type:
+           *   draftKey: string.
+           *   limit: number.
+           *   offset: number.
+           *   fields: string.
+           *   filters: string.
+           *   depth: number.
+           * Default: {}.
+           **/
+          query: {
+            draftKey: 'DRAFT_KEY',
+            limit: 100,
+            offset: 40,
+            fields: ['id', 'title', 'body'].join(','),
+            filters: 'tag[exists]',
+            depth: 2
+          }
+        }],
       },
     },
   ],
@@ -171,10 +173,12 @@ module.exports = {
     {
       resolve: 'gatsby-source-microcms',
       options: {
-        query: {
-          filters: and(contains('title', 'sale'), exists('tag')),
-          //=> `title[contains]sale[and]tag[exists]`
-        }
+        apis: [{
+          query: {
+            filters: and(contains('title', 'sale'), exists('tag')),
+            //=> `title[contains]sale[and]tag[exists]`
+          }
+        }]
       },
     },
   ],

--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -18,29 +18,29 @@ module.exports = {
       options: {
         apiKey: process.env.MICROCMS_API_KEY || MICROCMS_API_KEY,
         serviceId: process.env.MICROCMS_SERVICE_ID || MICROCMS_SERVICE_ID,
-        endpoint: 'gatsbylist',
-        query: {
-          limit: 100,
-          fields: [
-            'id',
-            'postsId',
-            'title',
-            'body',
-            'createdAt',
-            'updatedAt',
-          ].join(','),
-          filters: exists('title'),
-        },
+        apis: [
+          {
+            endpoint: 'gatsbylist',
+            format: 'list',
+            query: {
+              limit: 100,
+              fields: [
+                'id',
+                'postsId',
+                'title',
+                'body',
+                'createdAt',
+                'updatedAt',
+              ].join(','),
+              filters: exists('title'),
+            }
+          },
+          {
+            endpoint: 'gatsbyobject',
+            format: 'object'
+          }
+        ]
       },
-    },
-    {
-      resolve: require.resolve('../gatsby-node'),
-      options: {
-        apiKey: process.env.MICROCMS_API_KEY || MICROCMS_API_KEY,
-        serviceId: process.env.MICROCMS_SERVICE_ID || MICROCMS_SERVICE_ID,
-        endpoint: 'gatsbyobject',
-        format: 'object',
-      },
-    },
+    }
   ],
 };

--- a/src/__tests__/pluginOptions.js
+++ b/src/__tests__/pluginOptions.js
@@ -36,7 +36,9 @@ describe('validateOptions', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
+      apis: [{
+        endpoint: 'endpoint'
+      }],
     };
     validateOptions({ reporter }, options);
     expect(reporter.panic).not.toBeCalled();
@@ -46,7 +48,9 @@ describe('validateOptions', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'point',
+      apis: [{
+        endpoint: 'endpoint'
+      }],
     };
 
     Object.keys(options).forEach((key, index) => {
@@ -60,8 +64,10 @@ describe('validateOptions', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-      type: 'type',
+      apis: [{
+        endpoint: 'endpoint',
+        type: 'type',
+      }],
     };
     validateOptions({ reporter }, options);
     expect(reporter.panic).not.toBeCalled();
@@ -71,24 +77,35 @@ describe('validateOptions', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-      type: '',
+      apis: [{
+        endpoint: 'endpoint',
+        type: '',
+      }],
     };
     validateOptions({ reporter }, options);
     expect(reporter.panic.mock.calls.length).toBe(1);
   });
 
   test('format option should be success.', () => {
-    const options = {
+    const options = [{
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-    };
+      apis: [{
+        endpoint: 'endpoint',
+        format: 'list'
+      }],
+    },
+    {
+      apiKey: 'key',
+      serviceId: 'id',
+      apis: [{
+        endpoint: 'endpoint',
+        format: 'object'
+      }],
+    }];
 
-    const formats = ['list', 'object'];
-
-    for (let format of formats) {
-      validateOptions({ reporter }, { ...options, format });
+    for (let option of options) {
+      validateOptions({ reporter }, option);
       expect(reporter.panic).not.toBeCalled();
     }
   });
@@ -97,71 +114,54 @@ describe('validateOptions', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-      format: 'array',
+      apis: [{
+        endpoint: 'endpoint',
+        format: 'array'
+      }],
     };
 
     validateOptions({ reporter }, options);
     expect(reporter.panic.mock.calls.length).toBe(1);
-  });
-
-  test('valid readAll option should be success.', () => {
-    const options = {
-      apiKey: 'key',
-      serviceId: 'id',
-      endpoint: 'endpoint',
-      format: 'list',
-      readAll: true,
-    };
-
-    validateOptions({ reporter }, options);
-    expect(reporter.panic.mock.calls.length).toBe(0);
-  });
-
-  test('invalid readAll option should be fail.', () => {
-    const options = {
-      apiKey: 'key',
-      serviceId: 'id',
-      endpoint: 'endpoint',
-      format: 'list',
-      readAll: 'true',
-    };
-
-    validateOptions({ reporter }, options);
-    expect(reporter.panic.mock.calls.length).toBe(0);
   });
 
   test('draftKey option should be success.', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-      query: {
-        draftKey: 'DRAFT_KEY',
-      },
+      apis: [{
+        endpoint: 'endpoint',
+        query: {
+          draftKey: 'DRAFT_KEY',
+        },
+      }],
     };
     validateOptions({ reporter }, options);
     expect(reporter.panic).not.toBeCalled();
   });
 
-  test('invalide draftKey option should be error.', () => {
-    const options = {
+  test('invalid draftKey option should be error.', () => {
+    const options = (draftKey) => ({
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-    };
+      apis: [{
+        endpoint: 'endpoint',
+        query: {
+          draftKey,
+        },
+      }],
+    });
 
     // empty string
-    validateOptions({ reporter }, { ...options, query: { draftKey: '' } });
+    validateOptions({ reporter }, options(''));
     expect(reporter.panic.mock.calls.length).toBe(1);
     // float
-    validateOptions({ reporter }, { ...options, query: { draftKey: 1.3 } });
+    validateOptions({ reporter }, options(1.3));
     expect(reporter.panic.mock.calls.length).toBe(2);
     // object
-    validateOptions({ reporter }, { ...options, query: { draftKey: {} } });
+    validateOptions({ reporter }, options({}));
     expect(reporter.panic.mock.calls.length).toBe(3);
     // array
-    validateOptions({ reporter }, { ...options, draftKey: [2] });
+    validateOptions({ reporter }, options([2]));
     expect(reporter.panic.mock.calls.length).toBe(4);
   });
 
@@ -169,27 +169,34 @@ describe('validateOptions', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-      query: {
-        fields: ['id', 'title'].join(','),
-      },
+      apis: [{
+        endpoint: 'endpoint',
+        query: {
+          fields: ['id', 'title'].join(','),
+        },
+      }],
     };
     validateOptions({ reporter }, options);
     expect(reporter.panic).not.toBeCalled();
   });
 
   test('invalide fields option should be error.', () => {
-    const options = {
+    const options = (fields) => ({
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-    };
-    validateOptions({ reporter }, { ...options, query: { fields: {} } });
+      apis: [{
+        endpoint: 'endpoint',
+        query: {
+          fields,
+        },
+      }],
+    });
+    validateOptions({ reporter }, options({}));
     expect(reporter.panic.mock.calls.length).toBe(1);
 
     validateOptions(
       { reporter },
-      { ...options, query: { fields: ['id', 123] } }
+      options(['id', 123])
     );
     expect(reporter.panic.mock.calls.length).toBe(2);
   });
@@ -198,33 +205,40 @@ describe('validateOptions', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-      query: {
-        limit: 1,
-      },
+      apis: [{
+        endpoint: 'endpoint',
+        query: {
+          limit: 1,
+        },
+      }],
     };
     validateOptions({ reporter }, options);
     expect(reporter.panic).not.toBeCalled();
   });
 
   test('invalide limit option should be error.', () => {
-    const options = {
+    const options = (limit) => ({
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-    };
+      apis: [{
+        endpoint: 'endpoint',
+        query: {
+          limit,
+        },
+      }],
+    });
 
     // string
-    validateOptions({ reporter }, { ...options, query: { limit: 'abc' } });
+    validateOptions({ reporter }, options('abc'));
     expect(reporter.panic.mock.calls.length).toBe(1);
     // float
-    validateOptions({ reporter }, { ...options, query: { limit: 1.3 } });
+    validateOptions({ reporter }, options(1.3));
     expect(reporter.panic.mock.calls.length).toBe(2);
     // object
-    validateOptions({ reporter }, { ...options, query: { limit: {} } });
+    validateOptions({ reporter }, options({}));
     expect(reporter.panic.mock.calls.length).toBe(3);
     // array
-    validateOptions({ reporter }, { ...options, query: { limit: [2] } });
+    validateOptions({ reporter }, options([2]));
     expect(reporter.panic.mock.calls.length).toBe(4);
   });
 
@@ -232,33 +246,40 @@ describe('validateOptions', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-      query: {
-        offset: 1,
-      },
+      apis: [{
+        endpoint: 'endpoint',
+        query: {
+          offset: 1,
+        },
+      }],
     };
     validateOptions({ reporter }, options);
     expect(reporter.panic).not.toBeCalled();
   });
 
   test('invalide offset option should be error.', () => {
-    const options = {
+    const options = (offset) => ({
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-    };
+      apis: [{
+        endpoint: 'endpoint',
+        query: {
+          offset,
+        },
+      }],
+    });
 
     // string
-    validateOptions({ reporter }, { ...options, query: { offset: 'abc' } });
+    validateOptions({ reporter }, options('abc'));
     expect(reporter.panic.mock.calls.length).toBe(1);
     // float
-    validateOptions({ reporter }, { ...options, query: { offset: 1.3 } });
+    validateOptions({ reporter }, options(1.3));
     expect(reporter.panic.mock.calls.length).toBe(2);
     // object
-    validateOptions({ reporter }, { ...options, query: { offset: {} } });
+    validateOptions({ reporter }, options({}));
     expect(reporter.panic.mock.calls.length).toBe(3);
     // array
-    validateOptions({ reporter }, { ...options, offset: [2] });
+    validateOptions({ reporter }, options([2]));
     expect(reporter.panic.mock.calls.length).toBe(4);
   });
 
@@ -266,33 +287,40 @@ describe('validateOptions', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-      query: {
-        filters: 'tag[exists]',
-      },
+      apis: [{
+        endpoint: 'endpoint',
+        query: {
+          filters: 'tag[exists]',
+        },
+      }],
     };
     validateOptions({ reporter }, options);
     expect(reporter.panic).not.toBeCalled();
   });
 
   test('invalid filters option should be success.', () => {
-    const options = {
+    const options = (filters) => ({
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-    };
+      apis: [{
+        endpoint: 'endpoint',
+        query: {
+          filters,
+        },
+      }],
+    });
 
     // empty string
-    validateOptions({ reporter }, { ...options, query: { filters: '' } });
+    validateOptions({ reporter }, options(''));
     expect(reporter.panic.mock.calls.length).toBe(1);
     // number
-    validateOptions({ reporter }, { ...options, query: { filters: 100 } });
+    validateOptions({ reporter }, options(100));
     expect(reporter.panic.mock.calls.length).toBe(2);
     // object
-    validateOptions({ reporter }, { ...options, query: { filters: {} } });
+    validateOptions({ reporter }, options({}));
     expect(reporter.panic.mock.calls.length).toBe(3);
     // array
-    validateOptions({ reporter }, { ...options, filters: ['a', 2] });
+    validateOptions({ reporter }, options(['a', 2]));
     expect(reporter.panic.mock.calls.length).toBe(4);
   });
 
@@ -300,33 +328,40 @@ describe('validateOptions', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-      query: {
-        depth: 3,
-      },
+      apis: [{
+        endpoint: 'endpoint',
+        query: {
+          depth: 3,
+        },
+      }],
     };
     validateOptions({ reporter }, options);
     expect(reporter.panic).not.toBeCalled();
   });
 
   test('invalid depth option should be error.', () => {
-    const options = {
+    const options = (depth) => ({
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'endpoint',
-    };
+      apis: [{
+        endpoint: 'endpoint',
+        query: {
+          depth,
+        },
+      }],
+    });
 
     // string
-    validateOptions({ reporter }, { ...options, query: { depth: 'abc' } });
+    validateOptions({ reporter }, options('abc'));
     expect(reporter.panic.mock.calls.length).toBe(1);
     // float
-    validateOptions({ reporter }, { ...options, query: { depth: 1.3 } });
+    validateOptions({ reporter }, options(1.3));
     expect(reporter.panic.mock.calls.length).toBe(2);
     // over max int
-    validateOptions({ reporter }, { ...options, query: { depth: 4 } });
+    validateOptions({ reporter }, options(4));
     expect(reporter.panic.mock.calls.length).toBe(3);
     // array
-    validateOptions({ reporter }, { ...options, offset: ['11', 22] });
+    validateOptions({ reporter }, options(['11', 22]));
     expect(reporter.panic.mock.calls.length).toBe(4);
   });
 });

--- a/src/__tests__/sourceNodes.js
+++ b/src/__tests__/sourceNodes.js
@@ -20,13 +20,23 @@ beforeEach(() => {
   reporter.panic.mockClear();
 });
 
-const pluginOptions = {
+const listPluginOptions = {
   apiKey: 'key',
   serviceId: 'id',
-  endpoint: 'point',
-  format: 'list',
-  readAll: false,
   version: 'v1',
+  apis: [{
+    endpoint: 'list',
+  }]
+};
+
+const objectPluginOptions = {
+  apiKey: 'key',
+  serviceId: 'id',
+  version: 'v1',
+  apis: [{
+    endpoint: 'object',
+    format: 'object',
+  }]
 };
 
 describe('sourceNodes', () => {
@@ -35,7 +45,7 @@ describe('sourceNodes', () => {
       statusCode: 200,
       body: { contents: [{ id: '1' }, { id: '2' }], totalCount: 2 },
     };
-    await sourceNodes({ actions, createNodeId, reporter }, pluginOptions);
+    await sourceNodes({ actions, createNodeId, reporter }, listPluginOptions);
     expect(actions.createNode.mock.calls.length).toBe(2);
     expect(createNodeId.mock.calls.length).toBe(2);
     expect(reporter.panic).not.toBeCalled();
@@ -46,7 +56,7 @@ describe('sourceNodes', () => {
       statusCode: 400,
       body: { message: 'error' },
     };
-    await sourceNodes({ actions, createNodeId, reporter }, pluginOptions);
+    await sourceNodes({ actions, createNodeId, reporter }, listPluginOptions);
     expect(actions.createNode).not.toBeCalled();
     expect(createNodeId).not.toBeCalled();
     expect(reporter.panic.mock.calls.length).toBe(1);
@@ -59,7 +69,7 @@ describe('sourceNodes', () => {
     };
     await sourceNodes(
       { actions, createNodeId, reporter },
-      { ...pluginOptions, format: 'object' }
+      objectPluginOptions
     );
     expect(actions.createNode.mock.calls.length).toBe(1);
     expect(createNodeId.mock.calls.length).toBe(1);
@@ -70,7 +80,7 @@ describe('sourceNodes', () => {
     mockResponse = { statusCode: 400, body: { message: 'error' } };
     await sourceNodes(
       { actions, createNodeId, reporter },
-      { ...pluginOptions, format: 'list' }
+      objectPluginOptions
     );
     expect(actions.createNode).not.toBeCalled();
     expect(createNodeId).not.toBeCalled();
@@ -81,10 +91,11 @@ describe('sourceNodes', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'point',
-      format: 'list',
-      readAll: true,
       version: 'v1',
+      apis: [{
+        endpoint: 'point',
+        format: 'list',
+      }]
     };
     mockResponse = {
       statusCode: 200,
@@ -100,13 +111,14 @@ describe('sourceNodes', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'point',
-      format: 'list',
-      readAll: true,
       version: 'v1',
-      query: {
-        limit: 3,
-      },
+      apis: [{
+        endpoint: 'point',
+        format: 'list',
+        query: {
+          limit: 3,
+        },
+      }]
     };
     mockResponse = {
       statusCode: 200,
@@ -124,10 +136,11 @@ describe('sourceNodes', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'point',
-      format: 'list',
-      readAll: true,
       version: 'v1',
+      apis: [{
+        endpoint: 'point',
+        format: 'list',
+      }]
     };
     mockResponse = {
       statusCode: 400,
@@ -143,10 +156,11 @@ describe('sourceNodes', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'point',
-      format: 'list',
-      readAll: true,
       version: 'v1',
+      apis: [{
+        endpoint: 'point',
+        format: 'list',
+      }]
     };
     mockResponse = {
       statusCode: 200,
@@ -161,13 +175,14 @@ describe('sourceNodes', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'point',
-      format: 'list',
-      readAll: true,
       version: 'v1',
-      query: {
-        limit: 0,
-      },
+      apis: [{
+        endpoint: 'point',
+        format: 'list',
+        query: {
+          limit: 0,
+        },
+      }]
     };
     mockResponse = {
       statusCode: 200,
@@ -185,13 +200,14 @@ describe('sourceNodes', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'point',
-      format: 'list',
-      readAll: true,
       version: 'v1',
-      query: {
-        limit: 20,
-      },
+      apis: [{
+        endpoint: 'point',
+        format: 'list',
+        query: {
+          limit: 20,
+        },
+      }]
     };
     mockResponse = {
       statusCode: 200,
@@ -206,13 +222,14 @@ describe('sourceNodes', () => {
     const options = {
       apiKey: 'key',
       serviceId: 'id',
-      endpoint: 'point',
-      format: 'list',
-      readAll: true,
       version: 'v1',
-      query: {
-        limit: 1,
-      },
+      apis: [{
+        endpoint: 'point',
+        format: 'list',
+        query: {
+          limit: 1,
+        },
+      }]
     };
     mockResponse = {
       statusCode: 200,

--- a/src/pluginOptions.js
+++ b/src/pluginOptions.js
@@ -1,11 +1,7 @@
 const Joi = require('@hapi/joi');
 
 const defaultOptions = {
-  format: 'list',
   version: 'v1',
-  readAll: false,
-  fields: [],
-  query: {},
 };
 
 const createPluginConfig = pluginOptions => {
@@ -24,22 +20,23 @@ const optionsSchema = Joi.object().keys({
   serviceId: Joi.string()
     .required()
     .empty(),
-  apis: Joi.array()
+  apis: Joi.array().items(Joi.object({
+    endpoint: Joi.string().required().empty(),
+    type: Joi.string(),
+    format: Joi.string().pattern(/^(list|object)$/),
+    query: Joi.object({
+      draftKey: Joi.string(),
+      fields: Joi.string(),
+      limit: Joi.number().integer(),
+      offset: Joi.number().integer(),
+      filters: Joi.string(),
+      depth: Joi.number()
+        .integer()
+        .max(3),
+    }),
+  }))
     .required()
     .empty(),
-  type: Joi.string(),
-  format: Joi.string().pattern(/^(list|object)$/),
-  readAll: Joi.boolean(),
-  query: Joi.object({
-    draftKey: Joi.string(),
-    fields: Joi.string(),
-    limit: Joi.number().integer(),
-    offset: Joi.number().integer(),
-    filters: Joi.string(),
-    depth: Joi.number()
-      .integer()
-      .max(3),
-  }),
   version: Joi.string(),
   plugins: Joi.array(),
 });

--- a/src/pluginOptions.js
+++ b/src/pluginOptions.js
@@ -24,7 +24,7 @@ const optionsSchema = Joi.object().keys({
   serviceId: Joi.string()
     .required()
     .empty(),
-  endpoint: Joi.string()
+  apis: Joi.array()
     .required()
     .empty(),
   type: Joi.string(),

--- a/src/sourceNodes.js
+++ b/src/sourceNodes.js
@@ -20,8 +20,10 @@ const sourceNodes = async (
     // type option. default is endpoint value.
     const type = api.type || api.endpoint;
 
+    const { format = 'list' } = api;
+
     // get all list data
-    if (api.format === 'list') {
+    if (format === 'list') {
       let offset = 0;
       while (true) {
         const query = { ...api.query, offset };
@@ -61,17 +63,18 @@ message: ${body.message}`);
           break;
         }
       }
-    } else if (api.format === 'object') {
+    } else if (format === 'object') {
       // get object data
       const { statusCode, body } = await fetchData(apiUrl, {
         apiKey: pluginConfig.get('apiKey'),
-        query: pluginConfig.get('query'),
+        query: api.query,
       });
 
       if (statusCode !== 200) {
         reporter.panic(`microCMS API ERROR:
-  statusCode: ${statusCode}
-  message: ${body.message}`);
+statusCode: ${statusCode}
+message: ${body.message}`);
+        return;
       }
 
       createContentNode({

--- a/src/sourceNodes.js
+++ b/src/sourceNodes.js
@@ -1,8 +1,6 @@
 const { createPluginConfig } = require('./pluginOptions');
 const fetchData = require('./fetch');
 const {
-  isListContent,
-  isObjectContent,
   createContentNode,
 } = require('./utils');
 
@@ -13,94 +11,76 @@ const sourceNodes = async (
   const { createNode } = actions;
 
   const pluginConfig = createPluginConfig(pluginOptions);
-  const apiUrl = `https://${pluginConfig.get(
-    'serviceId'
-  )}.microcms.io/api/${pluginConfig.get('version')}/${pluginConfig.get(
-    'endpoint'
-  )}`;
-  // type option. default is endpoint value.
-  const type = pluginConfig.get('type') || pluginConfig.get('endpoint');
 
-  if (pluginConfig.get('readAll') && pluginConfig.get('format') === 'list') {
-    let offset = 0;
-    while (true) {
-      const query = { ...pluginConfig.get('query'), offset };
+  for await (const api of pluginConfig.get('apis')) {
+    const apiUrl = `https://${pluginConfig.get(
+      'serviceId'
+    )}.microcms.io/api/${pluginConfig.get('version')}/${api.endpoint}`;
+
+    // type option. default is endpoint value.
+    const type = api.type || api.endpoint;
+
+    // get all list data
+    if (api.format === 'list') {
+      let offset = 0;
+      while (true) {
+        const query = { ...api.query, offset };
+        const { statusCode, body } = await fetchData(apiUrl, {
+          apiKey: pluginConfig.get('apiKey'),
+          query,
+        });
+        if (statusCode !== 200) {
+          reporter.panic(`microCMS API ERROR:
+statusCode: ${statusCode}
+message: ${body.message}`);
+          return;
+        }
+
+        if (!Array.isArray(body.contents)) {
+          reporter.panic(`format set to 'list' but got ${typeof body.contents}`);
+          return;
+        }
+        body.contents.forEach(content => {
+          createContentNode({
+            createNode,
+            createNodeId,
+            content: content,
+            type: type,
+          });
+        });
+
+        const limit = query.limit || 10;
+
+        // totalCount not found
+        if (!body.totalCount) {
+          break;
+        }
+
+        offset += limit;
+        if (offset >= body.totalCount) {
+          break;
+        }
+      }
+    } else if (api.format === 'object') {
+      // get object data
       const { statusCode, body } = await fetchData(apiUrl, {
         apiKey: pluginConfig.get('apiKey'),
-        query,
+        query: pluginConfig.get('query'),
       });
+
       if (statusCode !== 200) {
         reporter.panic(`microCMS API ERROR:
-statusCode: ${statusCode}
-message: ${body.message}`);
-        return;
+  statusCode: ${statusCode}
+  message: ${body.message}`);
       }
 
-      if (!Array.isArray(body.contents)) {
-        reporter.panic(`format set to 'list' but got ${typeof body.contents}`);
-        return;
-      }
-      body.contents.forEach(content => {
-        createContentNode({
-          createNode,
-          createNodeId,
-          content: content,
-          type: type,
-        });
-      });
-
-      const limit = query.limit || 10;
-
-      // totalCount not found
-      if (!body.totalCount) {
-        break;
-      }
-
-      offset += limit;
-      if (offset >= body.totalCount) {
-        break;
-      }
-    }
-    return;
-  }
-
-  const { statusCode, body } = await fetchData(apiUrl, {
-    apiKey: pluginConfig.get('apiKey'),
-    query: pluginConfig.get('query'),
-  });
-
-  if (statusCode !== 200) {
-    reporter.panic(`microCMS API ERROR:
-statusCode: ${statusCode}
-message: ${body.message}`);
-  }
-
-  // list content
-  if (
-    isListContent({
-      format: pluginConfig.get('format'),
-      content: body.contents,
-    })
-  ) {
-    body.contents.forEach(content => {
       createContentNode({
         createNode,
         createNodeId,
-        content: content,
+        content: body,
         type: type,
       });
-    });
-  }
-  // object content
-  else if (
-    isObjectContent({ format: pluginConfig.get('format'), content: body })
-  ) {
-    createContentNode({
-      createNode,
-      createNodeId,
-      content: body,
-      type: type,
-    });
+    }
   }
 };
 


### PR DESCRIPTION
#6 

## 修正点

### インターフェースの変更
`endpoint`, `query`, `type`, `format`などAPI系の項目が`apis`配列内に移動

### readAllフラグの削除
list形式の場合は基本的に全件取得する必要があるので、readAllフラグは削除し、デフォルトで全件取得するように変更